### PR TITLE
feat/login-server

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,9 @@ function App() {
       <TopFixedBar />
       <Routes>
         <Route path="/" element={<MainPage />} />
+        <Route path="/auth/success" element={<MainPage />} />
         <Route path="/login" element={<LoginPage />} />
+        <Route path="/auth/failure" element={<LoginPage />} />
         <Route path="/join" element={<JoinPage />} />
         <Route path="/mypage" element={<MyPage />} />
         <Route path="/writing" element={<WritingPage />} />

--- a/src/api/getUser.ts
+++ b/src/api/getUser.ts
@@ -1,0 +1,9 @@
+async function getUser() {
+  return await fetch('/api/user', {
+    method: 'GET',
+  })
+    .then((response) => response.json())
+    .then((result) => result);
+}
+
+export default getUser;

--- a/src/api/loginApi.ts
+++ b/src/api/loginApi.ts
@@ -1,8 +1,22 @@
-// 현재 백 데이터가 없기 때문에 우선 가상의 API를 사용하여 작성(로그인이 무조건 성공된다고 가정)
 interface ILoginApi {
-  is_login: boolean;
+  email: string;
+  password: string;
 }
 
-export default function loginApi(id: string, password: string) {
-  return new Promise<ILoginApi>((resolve) => resolve({ is_login: true }));
+function loginApi({ email, password }: ILoginApi) {
+  const url = `/api/auth/login?email=${email}&password=${password}`;
+
+  return fetch(url, {
+    method: 'POST',
+  })
+    .then((response) => {
+      console.log(response);
+      return response.json();
+    })
+    .then((result) => {
+      console.log(result);
+      return result;
+    });
 }
+
+export default loginApi;

--- a/src/api/logoutApi.ts
+++ b/src/api/logoutApi.ts
@@ -1,0 +1,14 @@
+function logoutApi() {
+  const url = `api/auth/logout`;
+
+  fetch(url, {
+    method: 'POST',
+  })
+    .then((response) => {
+      console.log(response);
+      return response.json();
+    })
+    .then((result) => console.log(result));
+}
+
+export default logoutApi;

--- a/src/components/common/components/DropDownMenu.tsx
+++ b/src/components/common/components/DropDownMenu.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
 import { useState } from 'react';
 
 import { faHeart } from '@fortawesome/free-regular-svg-icons';
@@ -6,16 +7,24 @@ import { faBookmark } from '@fortawesome/free-regular-svg-icons';
 import { faFolder } from '@fortawesome/free-regular-svg-icons';
 
 import DropDownMenuIcon from './DropDownMenuIcon';
+import { authSlice } from '../../../redux-toolkit/slices/authSlice';
+import logoutApi from '../../../api/logoutApi';
 
 function DropDownMenu() {
   const imageUrl =
     'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png';
   const navigate = useNavigate();
+  const dispatch = useDispatch();
   const [showMenu, setShowMenu] = useState(true);
 
   const moveToMyPage = () => {
     navigate('/myPage');
     setShowMenu(!showMenu);
+  };
+  const setLogoutHandler = () => {
+    dispatch(authSlice.actions.logout());
+    logoutApi();
+    navigate('/');
   };
 
   return (
@@ -35,7 +44,10 @@ function DropDownMenu() {
             <DropDownMenuIcon icon={faFolder} text={'저장한 게시물'} />
           </div>
 
-          <button className="float-right mt-[-19px] pb-[1px] pr-[3px] text-[12px] text-deepGray">
+          <button
+            onClick={setLogoutHandler}
+            className="float-right mt-[-19px] pb-[1px] pr-[3px] text-[12px] text-deepGray"
+          >
             로그아웃
           </button>
         </div>

--- a/src/components/common/components/DropDownMenu.tsx
+++ b/src/components/common/components/DropDownMenu.tsx
@@ -21,8 +21,8 @@ function DropDownMenu() {
   return (
     <>
       {showMenu && (
-        <div className="bg-lightGray/10 border-[1px] border-deepGray">
-          <div className="flex h-[70px] bg-[white] pl-[10px] items-center">
+        <div className="bg-bgColor border-[1px] border-lightGray">
+          <div className="flex h-[70px] bg-[white] pl-[10px] items-center border-b-[1px] border-lightGray">
             <img src={imageUrl} className="w-[30px] h-[30px] rounded-[50%]" />
             <div className="ml-[3px] cursor-pointer" onClick={moveToMyPage}>
               고토리

--- a/src/components/common/components/IsHover.tsx
+++ b/src/components/common/components/IsHover.tsx
@@ -1,4 +1,4 @@
-import DropDownMenu from "./DropDownMenu";
+import DropDownMenu from './DropDownMenu';
 
 function IsHover() {
   return (

--- a/src/components/common/components/Logged.tsx
+++ b/src/components/common/components/Logged.tsx
@@ -34,12 +34,13 @@ function Logged({ propFunction }: any) {
           onMouseOver={() => {
             setIsHover(true);
           }}
-          onMouseOut={() => {
-            setIsHover(false);
+          onMouseOut={(e: any) => {
+            if (!e.currentTarget.contains(e.relatedTarget)) {
+              setIsHover(false);
+            }
           }}
         >
           <Icons icon={faUser} onClick={moveToMyPage} />
-          {/* isHover가 true일 때만 IsHover 컴포넌트 렌더링 */}
           {isHover && <IsHover />}
         </div>
       </div>

--- a/src/components/common/components/TopFixedBar.tsx
+++ b/src/components/common/components/TopFixedBar.tsx
@@ -1,6 +1,6 @@
-import { useSelector } from 'react-redux';
+import { useEffect, useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
-import { useState } from 'react';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
@@ -8,9 +8,12 @@ import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 import UnLogged from './UnLogged';
 import Logged from './Logged';
 import Hamburger from './Hamburger';
+import { authSlice } from '../../../redux-toolkit/slices/authSlice';
 import Logo from '../../../assets/logo/ms-icon-70x70.png';
+import getUser from '../../../api/getUser';
 
 function TopFixedBar() {
+  const dispatch = useDispatch();
   const navigate = useNavigate();
   const [menuToggle, setMenuToggle] = useState(false);
   const [isSearch, setIsSearch] = useState(false);
@@ -25,6 +28,13 @@ function TopFixedBar() {
   const showSearch = () => {
     setIsSearch(!isSearch);
   };
+
+  useEffect(() => {
+    (async function () {
+      let { status } = await getUser();
+      if (status === 200) dispatch(authSlice.actions.login(true));
+    })();
+  }, []);
 
   return (
     <>

--- a/src/components/common/components/TopFixedBar.tsx
+++ b/src/components/common/components/TopFixedBar.tsx
@@ -32,7 +32,10 @@ function TopFixedBar() {
   useEffect(() => {
     (async function () {
       let { status } = await getUser();
-      if (status === 200) dispatch(authSlice.actions.login(true));
+      if (status === 200) {
+        dispatch(authSlice.actions.login(true));
+        navigate('/');
+      }
     })();
   }, []);
 

--- a/src/components/login/Form.tsx
+++ b/src/components/login/Form.tsx
@@ -15,14 +15,17 @@ function Form() {
   const [isEmail, setIsEmail] = useState<boolean>(false);
   const [isPassword, setIsPassword] = useState<boolean>(false);
 
-  const onSubmitHandler = (e: React.FormEvent<HTMLFormElement>) => {
+  const onSubmitHandler = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    loginApi(email, password).then((result) => {
-      if (result.is_login) {
-        dispatch(authSlice.actions.login('tori'));
-        navigate('/');
-      } else navigate('/join');
-    });
+
+    let fetchedApi = await loginApi({ email, password });
+    if (fetchedApi.status === 200) {
+      dispatch(authSlice.actions.login(email));
+      navigate('/');
+    } else {
+      window.alert('등록되지 않은 이메일이거나 비밀번호가 일치하지 않습니다.');
+      navigate('/join');
+    }
   };
 
   return (

--- a/src/components/login/SocialLogin.tsx
+++ b/src/components/login/SocialLogin.tsx
@@ -11,10 +11,10 @@ function SocialLogin() {
         <Hr />
       </div>
 
-      <a href={''}>
+      <a href={'/api/auth/social/kakao'}>
         <img src={kakaoLogin} alt="카카오 로그인 버튼" className="w-[88%] m-auto mb-[2%]" />
       </a>
-      <a href={''} className="mt-[2%]">
+      <a href={'/api/auth/social/naver'} className="mt-[2%]">
         <img src={naverLogin} alt="네이버 로그인 버튼" className="w-[50%] m-auto" />
       </a>
     </div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,10 +9,10 @@ const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 
 root.render(
   <BrowserRouter>
-    <React.StrictMode>
-      <Provider store={store}>
-        <App />
-      </Provider>
-    </React.StrictMode>
+    {/* <React.StrictMode> */}
+    <Provider store={store}>
+      <App />
+    </Provider>
+    {/* </React.StrictMode> */}
   </BrowserRouter>
 );

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,8 +1,23 @@
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
 import H1 from '../components/common/components/H1';
 import Form from '../components/login/Form';
 import SocialLogin from '../components/login/SocialLogin';
 
 function LoginPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const searchParams = new URLSearchParams(location.search);
+  const error = searchParams.get('error');
+
+  useEffect(() => {
+    if (error) {
+      navigate('/login');
+      alert(error);
+    }
+  }, [error]);
+
   return (
     <div className="flex flex-col h-screen mt-[3%] items-center">
       <H1 name={'인터뷰북'} />

--- a/src/redux-toolkit/slices/authSlice.ts
+++ b/src/redux-toolkit/slices/authSlice.ts
@@ -1,17 +1,21 @@
 import { createSlice } from '@reduxjs/toolkit';
 
+interface IInitialState {
+  email: string;
+  username: string;
+  isLogin: boolean;
+}
+
+const initialState: IInitialState = { email: '', username: '', isLogin: false };
+
 export const authSlice = createSlice({
   name: 'auth',
-  initialState: { email: 0, username: '', isLogin: false },
+  initialState,
   reducers: {
     login: (state, action) => {
       state.email = action.payload;
       state.isLogin = true;
     },
-    logout: (state, action) => {
-      state.email = 0;
-      state.username = '';
-      state.isLogin = false;
-    },
+    logout: () => initialState,
   },
 });

--- a/src/redux-toolkit/slices/authSlice.ts
+++ b/src/redux-toolkit/slices/authSlice.ts
@@ -2,14 +2,14 @@ import { createSlice } from '@reduxjs/toolkit';
 
 export const authSlice = createSlice({
   name: 'auth',
-  initialState: { id: 0, username: '', isLogin: false },
+  initialState: { email: 0, username: '', isLogin: false },
   reducers: {
     login: (state, action) => {
-      state.id = action.payload;
+      state.email = action.payload;
       state.isLogin = true;
     },
     logout: (state, action) => {
-      state.id = 0;
+      state.email = 0;
       state.username = '';
       state.isLogin = false;
     },

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -3,12 +3,14 @@ const { createProxyMiddleware } = require('http-proxy-middleware');
 module.exports = function (app) {
   app.use(
     createProxyMiddleware(['/api'], {
-      target: 'https://ec2-3-39-238-222.ap-northeast-2.compute.amazonaws.com:18068',
+      target: 'http://ec2-43-201-65-255.ap-northeast-2.compute.amazonaws.com:18068/',
+      // target: 'http://192.168.0.21:18068',
       changeOrigin: true,
       onProxyReq: function (proxyReq) {
         proxyReq.setHeader(
           'origin',
-          'https://ec2-3-39-238-222.ap-northeast-2.compute.amazonaws.com:18068'
+          'http://ec2-43-201-65-255.ap-northeast-2.compute.amazonaws.com:18068/'
+          // 'http://192.168.0.21:18068'
         );
       },
     })

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -3,12 +3,12 @@ const { createProxyMiddleware } = require('http-proxy-middleware');
 module.exports = function (app) {
   app.use(
     createProxyMiddleware(['/api'], {
-      target: 'http://ec2-13-125-255-195.ap-northeast-2.compute.amazonaws.com:8068',
+      target: 'https://ec2-3-39-238-222.ap-northeast-2.compute.amazonaws.com:18068',
       changeOrigin: true,
       onProxyReq: function (proxyReq) {
         proxyReq.setHeader(
           'origin',
-          'http://ec2-13-125-255-195.ap-northeast-2.compute.amazonaws.com:8068'
+          'https://ec2-3-39-238-222.ap-northeast-2.compute.amazonaws.com:18068'
         );
       },
     })


### PR DESCRIPTION
## 로그인 성공
- `/auth/success?access-token=${}`
- `GET`, `/api/user`
    - 성공 시, 메인 페이지로 이동
    - `useNavigate`를 사용하여 URL 변경
    - `dispatch`를 사용하여 nickname 전달

## 로그인 실패
1. `/auth/failure?error=${}`
    - `react-router-dom`에서 제공되는 `useLocation` 사용을 사용하여 URL의 쿼리 매개변수 가져오기
2. 로그인 페이지로 이동 + alert
    - `Route`를 사용하여 로그인 페이지로 이동
    - `useNavigate`를 사용하여 URL 변경
    - `React.StrictMode`를 제거하여 alert가 2번 출력되는 이슈 해결

## 로그아웃
- `dispatch`를 사용하여 logout 액션 구현